### PR TITLE
Update jackson-databind

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="ff1c14ec-121e-431c-989e-e5098fd8da52" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/io/github/eliahkagan/bedj/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/io/github/eliahkagan/bedj/Main.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>service</artifactId>
             <version>0.10.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
By declaring it as a direct dependency.

This is an attempt to avoid using a vulnerable version of com.fasterxml.jackson.core:jackson-databind by adding it as a direct dependency, taking it from 2.10.1 to 2.14.2. The vulnerable version is affected by:

- CVE-2020-25649
- CVE-2020-36518
- CVE-2022-42003
- CVE-2022-42004